### PR TITLE
WIP: controller/certificate: move cert generation to cert controller

### DIFF
--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -16,7 +16,11 @@ oc delete --force --grace-period=0 -n openshift-ingress-operator clusteringresse
 
 if [ "$WHAT" == "all" ]; then
   oc delete namespaces/openshift-ingress-operator
+else
+  oc delete -n openshift-ingress-operator secrets/router-ca
+  oc delete -n openshift-ingress-operator events --all
 fi
+
 oc delete namespaces/openshift-ingress
 
 if [ "$WHAT" == "all" ]; then

--- a/pkg/operator/controller/certificate/ca.go
+++ b/pkg/operator/controller/certificate/ca.go
@@ -1,0 +1,152 @@
+package certificate
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// caCertSecretName is the name of the secret that holds the CA certificate
+	// that the operator will use to create default certificates for
+	// clusteringresses.
+	caCertSecretName = "router-ca"
+)
+
+// CASecretName returns the namespaced name for the router CA secret.
+func CASecretName(operatorNamespace string) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: operatorNamespace,
+		Name:      caCertSecretName,
+	}
+}
+
+func (r *reconciler) ensureRouterCASecret() (*corev1.Secret, error) {
+	current, err := r.currentRouterCASecret()
+	if err != nil {
+		return nil, err
+	}
+	if current != nil {
+		return current, nil
+	}
+	desired, err := desiredRouterCASecret(r.operatorNamespace)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.createRouterCASecret(desired); err != nil {
+		return nil, fmt.Errorf("failed to create CA secret: %v", err)
+	}
+	r.recorder.Event(desired, "Normal", "CreatedWildcardCACert", "Created a default wildcard CA certificate")
+	return desired, nil
+}
+
+// currentRouterCASecret returns the current router CA secret.
+func (r *reconciler) currentRouterCASecret() (*corev1.Secret, error) {
+	name := CASecretName(r.operatorNamespace)
+	secret := &corev1.Secret{}
+	if err := r.client.Get(context.TODO(), name, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secret, nil
+}
+
+// generateRouterCA generates and returns a CA certificate and key.
+func generateRouterCA() ([]byte, []byte, error) {
+	signerName := fmt.Sprintf("%s@%d", "cluster-ingress-operator", time.Now().Unix())
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate key: %v", err)
+	}
+
+	root := &x509.Certificate{
+		Subject: pkix.Name{CommonName: signerName},
+
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		NotBefore:    time.Now().Add(-1 * time.Second),
+		NotAfter:     time.Now().Add(2 * 365 * 24 * time.Hour),
+		SerialNumber: big.NewInt(1),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+
+		IsCA: true,
+
+		// Don't allow the CA to be used to make another CA.
+		MaxPathLen:     0,
+		MaxPathLenZero: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, root, root, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %v", err)
+	}
+
+	certs, err := x509.ParseCertificates(derBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse certificate: %v", err)
+	}
+
+	if len(certs) != 1 {
+		return nil, nil, fmt.Errorf("expected a single certificate")
+	}
+
+	certBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certs[0].Raw,
+	})
+
+	keyBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	return certBytes, keyBytes, nil
+}
+
+// desiredRouterCASecret returns the desired router CA secret.
+func desiredRouterCASecret(namespace string) (*corev1.Secret, error) {
+	certBytes, keyBytes, err := generateRouterCA()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate certificate: %v", err)
+	}
+
+	name := CASecretName(namespace)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+		},
+		Data: map[string][]byte{
+			"tls.crt": certBytes,
+			"tls.key": keyBytes,
+		},
+		Type: corev1.SecretTypeTLS,
+	}
+	return secret, nil
+}
+
+// createRouterCASecret creates the router CA secret.
+func (r *reconciler) createRouterCASecret(secret *corev1.Secret) error {
+	if err := r.client.Create(context.TODO(), secret); err != nil {
+		return err
+	}
+	log.Info("created secret", "namespace", secret.Namespace, "name", secret.Name)
+	return nil
+}

--- a/pkg/operator/controller/certificate/controller.go
+++ b/pkg/operator/controller/certificate/controller.go
@@ -7,28 +7,23 @@ package certificate
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
-	"math/big"
 	"time"
 
+	ingressv1alpha1 "github.com/openshift/cluster-ingress-operator/pkg/apis/ingress/v1alpha1"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
-
-	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"k8s.io/client-go/tools/record"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -36,25 +31,12 @@ import (
 )
 
 const (
-	// caCertSecretName is the name of the secret that holds the CA certificate
-	// that the operator will use to create default certificates for
-	// clusteringresses.
-	caCertSecretName = "router-ca"
-
 	controllerName = "certificate-controller"
 )
 
 var log = logf.Logger.WithName(controllerName)
 
-// CASecretName returns the namespaced name for the router CA secret.
-func CASecretName(operatorNamespace string) types.NamespacedName {
-	return types.NamespacedName{
-		Namespace: operatorNamespace,
-		Name:      caCertSecretName,
-	}
-}
-
-func New(mgr manager.Manager, client client.Client, operatorNamespace string, events <-chan event.GenericEvent) (controller.Controller, error) {
+func New(mgr manager.Manager, client client.Client, operatorNamespace string) (controller.Controller, error) {
 	reconciler := &reconciler{
 		client:            client,
 		recorder:          mgr.GetRecorder(controllerName),
@@ -64,7 +46,7 @@ func New(mgr manager.Manager, client client.Client, operatorNamespace string, ev
 	if err != nil {
 		return nil, err
 	}
-	if err := c.Watch(&source.Channel{Source: events}, &handler.EnqueueRequestForObject{}); err != nil {
+	if err := c.Watch(&source.Kind{Type: &ingressv1alpha1.ClusterIngress{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -77,119 +59,56 @@ type reconciler struct {
 }
 
 func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	current, err := r.currentRouterCASecret()
+	ca, err := r.ensureRouterCASecret()
 	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("failed to ensure router CA secret: %v", err)
 	}
-	if current != nil {
-		return reconcile.Result{}, nil
-	}
-	desired, err := desiredRouterCASecret(r.operatorNamespace)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	if err := r.createRouterCASecret(desired); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to create CA secret: %v", err)
-	}
-	r.recorder.Event(desired, "Normal", "CreatedWildcardCACert", "Created a default wildcard CA certificate")
-	return reconcile.Result{}, nil
-}
 
-// currentRouterCASecret returns the current router CA secret.
-func (r *reconciler) currentRouterCASecret() (*corev1.Secret, error) {
-	name := CASecretName(r.operatorNamespace)
-	secret := &corev1.Secret{}
-	if err := r.client.Get(context.TODO(), name, secret); err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
+	result := reconcile.Result{}
+	errs := []error{}
+	ingress := &ingressv1alpha1.ClusterIngress{}
+	if err := r.client.Get(context.TODO(), request.NamespacedName, ingress); err != nil {
+		if !errors.IsNotFound(err) {
+			// This means the ingress was already deleted/finalized and there are
+			// stale queue entries (or something edge triggering from a related
+			// resource that got deleted async).
+			log.Info("clusteringress not found; reconciliation will be skipped", "request", request)
+		} else {
+			errs = append(errs, fmt.Errorf("failed to get clusteringress: %v", err))
 		}
-		return nil, err
+	} else {
+		deployment := &appsv1.Deployment{}
+		err = r.client.Get(context.TODO(), routerDeploymentName(ingress), deployment)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// All ingresses should have a deployment, so this one may not have been
+				// created yet. Retry after a reasonable amount of time.
+				log.Info("deployment not found for %s; will retry default cert sync", "clusteringress", ingress.Name)
+				result.RequeueAfter = 5 * time.Second
+			} else {
+				errs = append(errs, fmt.Errorf("failed to get deployment: %v", err))
+			}
+		} else {
+			trueVar := true
+			deploymentRef := metav1.OwnerReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       deployment.Name,
+				UID:        deployment.UID,
+				Controller: &trueVar,
+			}
+			err = r.ensureDefaultCertificateForIngress(ca, deployment.Namespace, deploymentRef, ingress)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to ensure default cert for %s: %v", ingress.Name, err))
+			}
+		}
 	}
-	return secret, nil
+	return reconcile.Result{}, utilerrors.NewAggregate(errs)
 }
 
-// generateRouterCA generates and returns a CA certificate and key.
-func generateRouterCA() ([]byte, []byte, error) {
-	signerName := fmt.Sprintf("%s@%d", "cluster-ingress-operator", time.Now().Unix())
-
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate key: %v", err)
+func routerDeploymentName(ci *ingressv1alpha1.ClusterIngress) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: "openshift-ingress",
+		Name:      "router-" + ci.Name,
 	}
-
-	root := &x509.Certificate{
-		Subject: pkix.Name{CommonName: signerName},
-
-		SignatureAlgorithm: x509.SHA256WithRSA,
-
-		NotBefore:    time.Now().Add(-1 * time.Second),
-		NotAfter:     time.Now().Add(2 * 365 * 24 * time.Hour),
-		SerialNumber: big.NewInt(1),
-
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-
-		IsCA: true,
-
-		// Don't allow the CA to be used to make another CA.
-		MaxPathLen:     0,
-		MaxPathLenZero: true,
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, root, root, &privateKey.PublicKey, privateKey)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create certificate: %v", err)
-	}
-
-	certs, err := x509.ParseCertificates(derBytes)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse certificate: %v", err)
-	}
-
-	if len(certs) != 1 {
-		return nil, nil, fmt.Errorf("expected a single certificate")
-	}
-
-	certBytes := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: certs[0].Raw,
-	})
-
-	keyBytes := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
-	})
-
-	return certBytes, keyBytes, nil
-}
-
-// desiredRouterCASecret returns the desired router CA secret.
-func desiredRouterCASecret(namespace string) (*corev1.Secret, error) {
-	certBytes, keyBytes, err := generateRouterCA()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate certificate: %v", err)
-	}
-
-	name := CASecretName(namespace)
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
-		},
-		Data: map[string][]byte{
-			"tls.crt": certBytes,
-			"tls.key": keyBytes,
-		},
-		Type: corev1.SecretTypeTLS,
-	}
-	return secret, nil
-}
-
-// createRouterCASecret creates the router CA secret.
-func (r *reconciler) createRouterCASecret(secret *corev1.Secret) error {
-	if err := r.client.Create(context.TODO(), secret); err != nil {
-		return err
-	}
-	log.Info("created secret", "namespace", secret.Namespace, "name", secret.Name)
-	return nil
 }

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -169,7 +169,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 				}
 			} else {
 				// Handle everything else.
-				if err := r.ensureClusterIngress(ingress, caSecret, dnsConfig, infraConfig); err != nil {
+				if err := r.ensureClusterIngress(ingress, dnsConfig, infraConfig); err != nil {
 					errs = append(errs, fmt.Errorf("failed to ensure clusteringress: %v", err))
 				}
 			}
@@ -338,7 +338,7 @@ func (r *reconciler) ensureRouterNamespace() error {
 }
 
 // ensureClusterIngress ensures all necessary router resources exist for a given clusteringress.
-func (r *reconciler) ensureClusterIngress(ci *ingressv1alpha1.ClusterIngress, caSecret *corev1.Secret, dnsConfig *configv1.DNS, infraConfig *configv1.Infrastructure) error {
+func (r *reconciler) ensureClusterIngress(ci *ingressv1alpha1.ClusterIngress, dnsConfig *configv1.DNS, infraConfig *configv1.Infrastructure) error {
 	errs := []error{}
 
 	if deployment, err := r.ensureRouterDeployment(ci, infraConfig); err != nil {
@@ -358,12 +358,6 @@ func (r *reconciler) ensureClusterIngress(ci *ingressv1alpha1.ClusterIngress, ca
 		} else if lbService != nil {
 			if err := r.ensureDNS(ci, lbService, dnsConfig); err != nil {
 				errs = append(errs, fmt.Errorf("failed to ensure DNS for %s: %v", ci.Name, err))
-			}
-		}
-
-		if caSecret != nil {
-			if err := r.ensureDefaultCertificateForIngress(caSecret, deployment.Namespace, deploymentRef, ci); err != nil {
-				errs = append(errs, fmt.Errorf("failed to ensure default certificate for clusteringress %s: %v", ci.Name, err))
 			}
 		}
 


### PR DESCRIPTION
Relocate default wildcard certificate generation to the certificate controller to more
clearly decouple certificate management from ingress reconcilication.

Change the certificate controller event handling so that reconciliation is
triggered by clusteringress events. This makes the reconciliation code in the
controller easier to reason about and means we only do cert management if
there's a clusteringress around. It also means we can easily react to
clusteringresses being added/deleted.

Depends on https://github.com/openshift/cluster-ingress-operator/pull/139
